### PR TITLE
Move node destroy() from component 'beforeDestroy' to 'destroyed'

### DIFF
--- a/src/components/KonvaNode.js
+++ b/src/components/KonvaNode.js
@@ -44,7 +44,7 @@ export default function() {
       // this._stage.moveToTop();
       this.uploadKonva();
     },
-    beforeDestroy() {
+    destroyed() {
       this._stage.destroy();
     },
     methods: {


### PR DESCRIPTION
Node's stage was detroyed too early for allowing easy drag events manipulation with vue/vuex. By postponing stage destroy, it is now easier to know if dragend event is triggered from user input of from stage destroy.

----

This is part of my investigations from this thread : https://github.com/rafaesc/vue-konva/issues/2

I made this change after this discussion on Reac-Konva project : https://github.com/lavrton/react-konva/issues/182

I tried to reproduce this react-konva demo ( https://codesandbox.io/s/zxny6w50o4 ) but with vue-konva : https://codesandbox.io/s/2wl4m9p3ky

Both demos try to implement this behavior : 
- Display multiple draggable objects
- Those objects are synchronized with a redux/vuex store
- When dragged, those objects should be moved on top layer. To do this, component that contains dragged object is destroyed then re-created on top layer.

More generally, those demo show how to handle layer management using redux/vuex state without affecting drag events.

Demo that uses vue-konva does not work because stage is destroyed too early and so dragend event is also called too early. This implies that we can't differentiate a dragend triggered by user input or by component being destroyed.

⚠️ This change may has side effect as I modified KonvaNode's lifecycle. I don't know the vue lifecycle enough to predict how this will impact projects based on your framework.

Note: if you want to try the vue-konva demo in local, just download it and set `useEslint` to `false` in the `config/index.js` file. Or you'll have a lot of linter errors.